### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Property         | Variable               | Default              | Description
 `use_ssl`        | `SMTPD_USE_SSL`        | `False`              | Whether the fixture should use fixed TLS/SSL for transactions. If using smtplib requires that `SMTP_SSL` be used instead of `SMTP`.
 `use_starttls`   | `SMTPD_USE_STARTTLS`   | `False`              | Whether the fixture should use StartTLS to encrypt the connections. If using `smtplib` requires that `SMTP.starttls()` is called before other commands are issued. Overrides `use_tls` as the preferred method for securing communications with the client.
 `enforce_auth`   | `SMTPD_ENFORCE_AUTH`   | `False`              | If set to true then the fixture refuses MAIL, RCPT, DATA commands until authentication is completed.
-`ssl_cert_path`  | `SMTPD_SSL_CERTS_PATH` | `./certs/`           | The path to the key and certificate in PEM format for encryption with SSL/TLS or StartTLS.
 `ssl_cert_files` | `SMTPD_SSL_CERT_FILE` and `SMTPD_SSL_KEY_FILE` | `("cert.pem", None)` | A tuple of the path for the certificate file and key file in PEM format.
 
 ## Alternatives
@@ -148,12 +147,12 @@ Quick tests can be handled by running pytest directly:
 pytest
 ```
 
-We include a [pre-commit](https://pre-commit.com/) configuration file to automate checks and clean up imports before pushing code. In order to install pre-commit git hooks:
+<!-- We include a [pre-commit](https://pre-commit.com/) configuration file to automate checks and clean up imports before pushing code. In order to install pre-commit git hooks:
 
 ```bash
 pip install pre-commit
 pre-commit install
-```
+``` -->
 
 ## Known Issues
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Version 0.1.1
+
+Release Date: 2024-04-21
+
+- Drops support for python 3.7 and adds testing against python 3.12
+- Updates README to reflect changes in `smtpdfix` version 0.5.3
+
 ## Version 0.1.0
 
 Release Date: 2023-05-15


### PR DESCRIPTION
Updates README to reflect:
- ssl_cert_path property has been deprecated in `smtpdfix`.
- there is no pre-commit configuration file included in the source.

Closes #9